### PR TITLE
GitHub package publishing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,14 +105,9 @@
     </build>
 
     <distributionManagement>
-        <snapshotRepository>
-            <id>dcc-snapshot</id>
-            <name>artifacts.oicr.on.ca-snapshots</name>
-            <url>https://artifacts.oicr.on.ca/artifactory/dcc-snapshot</url>
-        </snapshotRepository>
         <repository>
-            <id>dcc-release</id>
-            <name>artifacts.oicr.on.ca-releases</name>
+            <id>github</id>
+            <name>GitHub Overture Apache Maven Packages</name>
             <url>https://artifacts.oicr.on.ca/artifactory/dcc-release</url>
         </repository>
     </distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <repository>
             <id>github</id>
             <name>GitHub Overture Apache Maven Packages</name>
-            <url>https://artifacts.oicr.on.ca/artifactory/dcc-release</url>
+            <url>https://maven.pkg.github.com/overture-stack/aria</url>
         </repository>
     </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>bio.overture</groupId>
     <artifactId>aria</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>A Reactive SONG/SCORE API</description>


### PR DESCRIPTION
changed the package url where artifacts are published. Aria artifacts will now be published to the github registry